### PR TITLE
Docs update

### DIFF
--- a/components/Layout.tsx
+++ b/components/Layout.tsx
@@ -4,7 +4,7 @@ import Link from "next/link";
 import { Root, Main, Footer } from "@dvargas92495/ui";
 import dynamic from "next/dynamic";
 
-const PAGES = ["extensions", "faq"] as const;
+const PAGES = ["extensions", "FAQ"] as const;
 
 export type LayoutProps = {
   title?: string;
@@ -57,7 +57,7 @@ const Layout: React.FunctionComponent<LayoutProps> = ({
             {PAGES.map((p, i) => (
               <h6 key={i}>
                 <a
-                  href={`/${p}`}
+                  href={`/${p.toLowerCase()}`}
                   color="inherit"
                   className={`${
                     activeLink === p ? "text-gray-800" : "text-gray-400"

--- a/components/MdxComponents.tsx
+++ b/components/MdxComponents.tsx
@@ -1,10 +1,4 @@
 import {
-  H1,
-  H2,
-  H3,
-  H4,
-  H5,
-  H6,
   Body,
   LI,
 } from "@dvargas92495/ui";
@@ -125,6 +119,25 @@ const Blockquote: React.FunctionComponent<{ id: string }> = ({ children }) => {
     </blockquote>
   );
 };
+
+const H1 = ({ children }) => (
+  <h1 className="MuiTypography-root MuiTypography-h1" id={children.toLowerCase().replace(/ /g, "-")}>{children}</h1>
+  )
+const H2 = ({ children }) => (
+  <h2 className="MuiTypography-root MuiTypography-h2" id={children.toLowerCase().replace(/ /g, "-")}>{children}</h2>
+)
+const H3 = ({ children }) => (
+  <h3 className="MuiTypography-root MuiTypography-h3" id={children.toLowerCase().replace(/ /g, "-")}>{children}</h3>
+)
+const H4 = ({ children }) => (
+  <h4 className="MuiTypography-root MuiTypography-h4" id={children.toLowerCase().replace(/ /g, "-")}>{children}</h4>
+)
+const H5 = ({ children }) => (
+  <h5 className="MuiTypography-root MuiTypography-h5" id={children.toLowerCase().replace(/ /g, "-")}>{children}</h5>
+)
+const H6 = ({ children }) => (
+  <h6 className="MuiTypography-root MuiTypography-h6" id={children.toLowerCase().replace(/ /g, "-")}>{children}</h6>
+)
 
 const getMdxComponents = (): Record<string, React.ReactNode> => ({
   h1: H1,

--- a/components/global.css
+++ b/components/global.css
@@ -87,3 +87,11 @@ img.thumbnail {
 .roamjs-user-card .MuiListItem-root {
   display: flex;
 }
+
+summary {
+  margin: 1em 0;
+  font-size: 1rem;
+  font-family: Avenir Light,sans-serif;
+  font-weight: 400;
+  line-height: 1.5;
+}

--- a/pages/extensions/[id].tsx
+++ b/pages/extensions/[id].tsx
@@ -204,7 +204,7 @@ const ExtensionPage = ({
         </>
       ) : (
         <p>
-          This extension is avaiable in Roam Depot! Install it directly from
+          This extension is available in Roam Depot! Install it directly from
           Roam by navigating to Settings {">"} RoamDepot {">"} Browse. To help
           test a development version of the extension before it's available in
           Roam Depot,{" "}


### PR DESCRIPTION
**add id to headers**
the `typography` component was importing and overriding a bunch of CSS, so I just want with the HTML route.


https://user-images.githubusercontent.com/3792666/215665682-82f14405-8496-4350-b98c-243f46fe6da0.mp4


@dvargas92495 